### PR TITLE
Compile Node Software in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,17 @@
-FROM ubuntu:18.04
+FROM golang:1.13 AS build
 
+# Build node
 WORKDIR /app
+RUN git clone https://github.com/ontio/ontology-rosetta && \
+  cd ontology-rosetta && \
+  make rosetta-node
 
-COPY ./rosetta-node /app/
-COPY ./start.sh /app
+FROM golang:1.13
+
+# Copy node binary from build
+WORKDIR /app
+COPY --from=build /app/ontology-rosetta/rosetta-node rosetta-node
+COPY --from=build /app/ontology-rosetta/start.sh start.sh
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,18 @@
+# Build rosetta-node
 FROM golang:1.13 AS build
-
-# Build node
 WORKDIR /app
 RUN git clone https://github.com/ontio/ontology-rosetta && \
   cd ontology-rosetta && \
   make rosetta-node
 
-FROM golang:1.13
-
 # Copy node binary from build
+FROM golang:1.13
 WORKDIR /app
 COPY --from=build /app/ontology-rosetta/rosetta-node rosetta-node
 COPY --from=build /app/ontology-rosetta/start.sh start.sh
 
 EXPOSE 8080
 
-#should have a volume mount for /data
-# append more rosetta-node args after image in docker run command, e.g. docker run ontology-rosetta:0.4 -- --network-id 2
+# start.sh assumes there exists a volume mounted at /data that contains
+# a rosetta-config.json file.
 ENTRYPOINT ["/app/start.sh"]

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,6 @@ rosetta-node-darwin:
 all-cross: rosetta-node-cross
 
 docker:
-	docker run -v $(PWD):/go/src/github.com/ontio/ontology-rosetta  golang:1.13 bash -c 'cd /go/src/github.com/ontio/ontology-rosetta && make -f Makefile'
 	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_VERSION) .
 
 format:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ Ontology node which follows Rosetta BlockChain Standard
 ## Build docker image
 
 ```sh
-make clean
 make docker
 ```
 
@@ -38,7 +37,7 @@ The default configuration file is rosetta-config.json
 }
 ```
 
-* rosetta 
+* rosetta
   * version : rosetta sdk version
   * port: rosetta restful api port
   * block_wait_time : rosetta compute historical balance block wait time
@@ -93,7 +92,7 @@ Use the available "network_identifier" from /network/list
             "blockchain": "ont",
             "network": "mainnet"
         }
-    
+
 }
 ```
 
@@ -248,7 +247,7 @@ Use the available "network_identifier" from /network/list
             "blockchain": "ont",
             "network": "mainnet"
         }
-    
+
 }
 ```
 
@@ -401,8 +400,8 @@ Request:
         },
     "block_identifier": {
         "index":54
-    }    
-    
+    }
+
 }
 ```
 
@@ -503,7 +502,7 @@ Request:
     "transaction_identifier": {
         "hash": "20247d9df50d830b8978a5c49313a6f8a118fd5bb9c2950e3c7f95f5ac6410f6"
     }
-    
+
 }
 ```
 
@@ -691,7 +690,7 @@ Request:
     "transaction_identifier": {
         "hash": "20247d9df50d830b8978a5c49313a6f8a118fd5bb9c2950e3c7f95f5ac6410f6"
     }
-    
+
 }
 ```
 


### PR DESCRIPTION
### Motivation
When using Docker, binaries needed for runtime should be built inside the container (with the compilation steps defined in the `Dockerfile`) instead of copying them in from outside. Copying binaries built outside the container will prevent some users from running the built container if their OS does not match the one used by the container.

For example, when running `make docker` on a Mac you will get the following error when trying to run the container:
```
/app/start.sh: line 5: /app/rosetta-node: cannot execute binary file: Exec format error
```
### Improvements
* Build node binary in `Dockerfile`
* Use [multi-stage builds](https://docs.docker.com/develop/develop-images/multistage-build/#use-multi-stage-builds)

### Future PR
* Use a smaller image for runtime (maybe `FROM alpine` instead of `FROM golang:1.13`?)