### PR TITLE
Distinguish mint/burn operations from two-sided transfers

### DIFF
--- a/services/block_service.go
+++ b/services/block_service.go
@@ -127,6 +127,12 @@ func (s *service) appendOperations(ops []*types.Operation, xfer *transferInfo, s
 	// only the gas fee transfers would have been indexed for transactions
 	// that failed.
 	if xfer.from != nullAddr {
+		typ := opTransfer
+		if xfer.to == nullAddr {
+			typ = opBurn
+		} else if xfer.isGas {
+			typ = opGasFee
+		}
 		op := &types.Operation{
 			Account: &types.AccountIdentifier{
 				Address: xfer.from.ToBase58(),
@@ -138,7 +144,7 @@ func (s *service) appendOperations(ops []*types.Operation, xfer *transferInfo, s
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: int64(len(ops)),
 			},
-			Type: opTransfer,
+			Type: typ,
 		}
 		if setStatus {
 			op.Status = &statusSuccess
@@ -148,13 +154,16 @@ func (s *service) appendOperations(ops []*types.Operation, xfer *transferInfo, s
 				Address: xfer.contract.ToHexString(),
 			}
 		}
-		if xfer.isGas {
-			op.Type = opGasFee
-		}
 		related = true
 		ops = append(ops, op)
 	}
 	if xfer.to != nullAddr {
+		typ := opTransfer
+		if xfer.from == nullAddr {
+			typ = opMint
+		} else if xfer.isGas {
+			typ = opGasFee
+		}
 		op := &types.Operation{
 			Account: &types.AccountIdentifier{
 				Address: xfer.to.ToBase58(),
@@ -166,7 +175,7 @@ func (s *service) appendOperations(ops []*types.Operation, xfer *transferInfo, s
 			OperationIdentifier: &types.OperationIdentifier{
 				Index: int64(len(ops)),
 			},
-			Type: opTransfer,
+			Type: typ,
 		}
 		if setStatus {
 			op.Status = &statusSuccess
@@ -175,9 +184,6 @@ func (s *service) appendOperations(ops []*types.Operation, xfer *transferInfo, s
 			op.Account.SubAccount = &types.SubAccountIdentifier{
 				Address: xfer.contract.ToHexString(),
 			}
-		}
-		if xfer.isGas {
-			op.Type = opGasFee
 		}
 		if related {
 			op.RelatedOperations = []*types.OperationIdentifier{

--- a/services/services.go
+++ b/services/services.go
@@ -37,7 +37,9 @@ import (
 
 const (
 	defaultGasPrice = 2500
+	opBurn          = "burn"
 	opGasFee        = "gas_fee"
+	opMint          = "mint"
 	opTransfer      = "transfer"
 )
 
@@ -51,7 +53,7 @@ var (
 
 var (
 	minGasLimit   = neovm.MIN_TRANSACTION_GAS
-	opTypes       = []string{opGasFee, opTransfer}
+	opTypes       = []string{opBurn, opGasFee, opMint, opTransfer}
 	statusFailed  = "FAILED"
 	statusSuccess = "SUCCESS"
 )

--- a/version/version.go
+++ b/version/version.go
@@ -21,5 +21,5 @@ package version
 
 const (
 	Node    = "1.13.2"
-	Rosetta = "1.13.4"
+	Rosetta = "1.13.5"
 )


### PR DESCRIPTION
This PR adds `mint` and `burn` operation types that are distinct from `transfer` operations. Transfers from the null address are interpreted as a `mint` operation, and transfers to the null address are interpreted as a `burn` operation.