### PR TITLE
Add mechanism to validate indexed store data against the on chain data

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Objects within the `oep4_tokens` array must follow this structure:
 }
 ```
 
+## Dev Notes
+
+When changes are made to the internal `services/store.go` code, it should be
+verified by:
+
+* First running the server so that the network is synced to a reasonable depth —
+  as close to tip as possible.
+
+* Re-running the server with the `--validate-store` option to check that the
+  indexed store state matches up with the on chain state.
+
 ## Rosetta API
 
 ### Network

--- a/main.go
+++ b/main.go
@@ -371,7 +371,7 @@ func run(ctx *cli.Context) {
 	cfg := initNodeConfig(ctx)
 	scfg := initServerConfig(ctx)
 	if cliBool(ctx, validateStoreFlag) {
-		runValidateStore(cfg, scfg)
+		runValidateStore(ctx, cfg, scfg)
 	} else if cliBool(ctx, offlineFlag) {
 		runOffline(ctx, cfg, scfg)
 	} else {
@@ -398,15 +398,16 @@ func runOnline(ctx *cli.Context, cfg *config.OntologyConfig, scfg *serverConfig)
 	}
 }
 
-func runValidateStore(cfg *config.OntologyConfig, scfg *serverConfig) {
-	ctx := context.Background()
+func runValidateStore(ctx *cli.Context, cfg *config.OntologyConfig, scfg *serverConfig) {
+	initLedger(ctx, cfg)
 	store := initStore(cfg, scfg, false)
 	log.Info("Started indexing any missing blocks")
-	store.IndexBlocks(ctx, services.IndexConfig{
+	store.IndexBlocks(context.Background(), services.IndexConfig{
 		ExitEarly: true,
 		WaitTime:  scfg.waitTime,
 	})
 	log.Info("Finished indexing blocks")
+	store.Validate()
 }
 
 func setMaxOpenFiles() {

--- a/services/services.go
+++ b/services/services.go
@@ -73,6 +73,13 @@ type IndexConfig struct {
 	WaitTime  time.Duration
 }
 
+type accountInfo struct {
+	acct     common.Address
+	contract common.Address
+	key      []byte
+	native   bool
+}
+
 type balanceChange struct {
 	diff   *big.Int
 	key    []byte


### PR DESCRIPTION
This PR adds a process to sanity check that the computed historic balances (from smart contract events) match up with the on chain state. This process is run when the `--validate-store` CLI option is specified.

When run against the testnet tip, the validation passes for native contracts like ONT and ONG :tada:

However, for the OEP4 `WING` token, the balance for address `AG4pZwKa9cr8ca7PED7FqzUfcwnrQ2N26w` does not match up. There's a discrepancy of exactly 2,000,000 `WING` between the on chain balance and the balance computed from smart contract events.

It looks like those 2M WING tokens may form some kind of escrow and may not yet have been minted? I tried to look for the contract code, but the only link I found returns a 404: https://github.com/wing-groups/wing-dao-contracts/blob/master/neovm/wing.py

When it becomes important to support OEP4 tokens, it'd be good to extend the implementation to read from config for `bootstrap_balances`, e.g. https://github.com/coinbase/rosetta-ethereum/blob/master/rosetta-cli-conf/testnet/bootstrap_balances.json

Thanks!