### PR TITLE
multiply ONT and ONG amounts with GWei Constant to fix decimals

### DIFF
--- a/services/store.go
+++ b/services/store.go
@@ -986,8 +986,9 @@ func decodeTransfer(height uint32, info *event.ExecuteNotify, evt *event.NotifyE
 			}
 			return xfer
 		}
+		res := big.NewInt(0).Mul(big.NewInt(amount), big.NewInt(constants.GWei))
 		xfer := &transfer{
-			amount: big.NewInt(amount),
+			amount: res,
 			from:   from,
 			to:     to,
 		}


### PR DESCRIPTION
Multiplying ONT and ONG amounts with 1e9 in transfer operations for transactions to fix decimals for rosetta validations